### PR TITLE
Balisage des liens, citations et images

### DIFF
--- a/fr_FR/pages/syntaxemarkdown.md
+++ b/fr_FR/pages/syntaxemarkdown.md
@@ -37,7 +37,7 @@ Voici mon texte[^1]
 
 ## Italiques et gras
 
-- L'italique se balise avec des ```_````avant et après le mot ou l'expression en italique. Par exemple:
+- L'italique se balise avec des ```_``` avant et après le mot ou l'expression en italique. Par exemple:
 ```
 Voici un _mot_ en italique
 ```
@@ -47,7 +47,7 @@ Donnerai:
 Voici un _mot_ en italique
 
 
-- Le gras se balise avec deux ```**````avant et après le mot ou l'expression en italique. Par exemple:
+- Le gras se balise avec deux ```**``` avant et après le mot ou l'expression en italique. Par exemple:
 ```
 Voici un **mot** en gras
 ```
@@ -60,6 +60,16 @@ Voici un **mot** en gras
 ## Images
 
 ## Liens
+Les liens se balisent en distinguant :
+
+- le lien, c'est-à-dire le mot ou l'expression indiqué comme un lien, avec des crochets `[]` ;
+- et la cible, l'URL de destination, avec des parenthèses `()`.
+
+Voici [un lien vers une page Wikipédia](https://fr.wikipedia.org/wiki/Hyperlien), et les balises correspondantes :
+
+```
+[un lien vers une page Wikipédia](https://fr.wikipedia.org/wiki/Hyperlien)
+```
 
 ## Citations
 
@@ -79,4 +89,3 @@ Donnera en HTML:
 ```
 Voici la <span class="these">thèse fondamentale de l'article</span>
 ```
-

--- a/fr_FR/pages/syntaxemarkdown.md
+++ b/fr_FR/pages/syntaxemarkdown.md
@@ -72,7 +72,17 @@ Voici [un lien vers une page Wikipédia](https://fr.wikipedia.org/wiki/Hyperlien
 ```
 
 ## Citations
+Une citation peut être indiquée sémantiquement par le biais du balisage suivant : un crochet fermant suivi d'un espace en début de paragraphe `> `.
+Voici un exemple de citation :
 
+> Un lien hypertexte ou hyperlien permet en cliquant dessus d'atteindre un autre endroit de la page, une autre page ou un autre site évalué comme pertinent par l'auteur.
+> Source : [Wikipédia](https://fr.wikipedia.org/wiki/Hyperlien)
+
+Et voici le balisage correspondant :
+```
+> Un lien hypertexte ou hyperlien permet en cliquant dessus d'atteindre un autre endroit de la page, une autre page ou un autre site évalué comme pertinent par l'auteur.
+> Source : [Wikipédia](https://fr.wikipedia.org/wiki/Hyperlien)
+```
 
 ## Balisage sémantique
 

--- a/fr_FR/pages/syntaxemarkdown.md
+++ b/fr_FR/pages/syntaxemarkdown.md
@@ -58,6 +58,21 @@ Voici un **mot** en gras
 
 
 ## Images
+Une image peut être intégrée à un document rédigé avec le langage de balisage Markdown avec le balisage suivant :
+
+- un point d'exclamation `!` ;
+- suivi de crochets `[]` comportant la description de l'image ;
+- puis de parenthèses `()` comportant le chemin ou l'adresse de l'image.
+
+Voici une image, en l'occurrence le logo du W3C (World Wide Web Consortium) :
+
+![Logo du W3C composé de la lettre W en bleu, du chiffre 3 en bleu et de la lettre C en noir](https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/W3C_icon.svg/212px-W3C_icon.svg.png)
+
+Et voici le balisage correspondant :
+
+```
+![Logo du W3C composé de la lettre W en bleu, du chiffre 3 en bleu et de la lettre C en noir](https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/W3C_icon.svg/212px-W3C_icon.svg.png)
+```
 
 ## Liens
 Les liens se balisent en distinguant :


### PR DESCRIPTION
Compléments de la documentation, et au passage correction de balisage de cette page (code qui débordait), suite à une discussion avec une utilisatrice de Stylo qui ne savait pas comment faire les liens :+1: 