### PR TITLE
Supprime le nom de domaine.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-stylo-doc.ecrituresnumeriques.ca


### PR DESCRIPTION
Car la documentation est maintenant gérée sur https://github.com/EcrituresNumeriques/stylo.

Le dépôt peut être archivé.